### PR TITLE
Adding reference to PSGallery key.

### DIFF
--- a/Build/full-release-pipeline.ps1
+++ b/Build/full-release-pipeline.ps1
@@ -29,7 +29,7 @@ Process {
                 Write-Status Success "Passed all POST-Build Tests."
                 If (-Not($DoNotPublish.IsPresent)) {
                     Write-Status Info "Publishing Module..."
-                    Publish-ThisModule
+                    Publish-ThisModule -PSGalleryApiKey $PSGalleryApiKey
                     Write-Status Success "Successfully published."
                 }
             } Else {


### PR DESCRIPTION
Since functions were extracted into the BuildHelpers.psm1 module file, I need to now pass the parameter directly to the function.