### PR TITLE
Significant performance improvement to Merge-CIDRIpRanges function.

### DIFF
--- a/AdminToolkit.psd1
+++ b/AdminToolkit.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AdminToolkit.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1.2'
+ModuleVersion = '1.1.2.1'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog for AdminToolkit
 
+## v1.1.2.1
+
++ `Merge-CIDRIpRanges`
+  + Significant performance improvement to `Merge-CIDRIpRanges` function.
+
 ## v1.1.2
 
 + **New Functions:**
   + **Public**
-    + `Merge-CIDRIpAddressRanges`
+    + `Merge-CIDRIpRanges`
       + Reduces a list of CIDR IP Ranges to a single list of ranges that do not overlap.
     + `Get-IPv4NetworkInfo`
       + Gets extended information about an IPv4 network.


### PR DESCRIPTION
This creates a stripped-down internal function of `Get-IPv4NetworkInfo` to include the bare minimum calculations needed for this CIDR command. Including returning a [pscustomobject] vs using `Add-Member` on a `New-Object`.

Additionally, this CIDR function now returns survivor IP ranges as they are detected instead of building up a massive list to return at the end. This is better in terms of proper pipeline support. Objects are returned when they are calculated.